### PR TITLE
Add a build props file to force root container users when people publish containers with this library

### DIFF
--- a/src/Actions.Core/Actions.Core.csproj
+++ b/src/Actions.Core/Actions.Core.csproj
@@ -69,6 +69,7 @@
   <ItemGroup Label="Files">
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="build/**" Pack="true" PackagePath="build/" />
   </ItemGroup>
     
   <ItemGroup>

--- a/src/Actions.Core/build/GitHub.Actions.Core.props
+++ b/src/Actions.Core/build/GitHub.Actions.Core.props
@@ -1,0 +1,16 @@
+<Project>
+    <PropertyGroup>
+        <!-- Provide a global opt-out for our modifications - a user can set IsTargetingGithubActions to false to make sure we don't do anything -->
+        <IsTargetingGithubActions 
+            Condition="'$(IsTargetingGithubActions)' == ''" >true</IsTargetingGithubActions>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(IsTargetingGithubActions)' == 'true'">
+        <!-- Per https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user, 
+             GitHub Actions must run as root in order to not break sevearl system invariants.
+             By default, let's make sure that users of this Actions-related library don't run
+             face-first into any problems, since the .NET SDK Container builds default to rootless
+             container users -->
+        <ContainerUser>root</ContainerUser>
+    </PropertyGroup>
+</Project>

--- a/src/Actions.IO/Actions.IO.csproj
+++ b/src/Actions.IO/Actions.IO.csproj
@@ -52,7 +52,7 @@
 
   <ItemGroup Label="Files">
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
-    <None Include="README.md" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As we found, Actions that are container-based must execute as root. Per[ the docs](https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user):

> Docker actions must be run by the default Docker user (root). Do not use the USER instruction in your Dockerfile, because you won't be able to access the GITHUB_WORKSPACE directory. For more information, see "[Variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)" and [USER reference](https://docs.docker.com/engine/reference/builder/#user) in the Docker documentation.

We can help users enforce this invariant, while also giving them a chance to skip if they promise they know what they're doing.

A binlog shows:

the import
![image](https://github.com/IEvangelist/dotnet-github-actions-sdk/assets/573979/2e11f418-06b9-470f-81a5-a83cb8cebd02)

the property set
![image](https://github.com/IEvangelist/dotnet-github-actions-sdk/assets/573979/af61b296-dda7-47e6-991f-d7ae33689533)
