### PR TITLE
Repo rename URL sweep + MinVer tag prefix

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -50,6 +50,6 @@
   "skipCi": true,
   "repoType": "github",
   "repoHost": "https://github.com",
-  "projectName": "dotnet-github-actions-sdk",
+  "projectName": "actions-toolkit-csharp",
   "projectOwner": "IEvangelist"
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,13 +21,24 @@
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors> 
 
+        <!--
+          MinVer reads version from git tags. The legacy `9.0.0` and `10.0` tags
+          (no `v` prefix) belong to the previous `GitHub.Actions.*` lineage; the
+          `ActionsToolkit.*` packages start a new versioning epoch using `v*`
+          tags so MinVer ignores those legacy anchors. The first new tag will
+          be `v0.0.1-pre.0` (or `v1.0.0` when ready); until then MinVer falls
+          back to a default `0.0.0-alpha.0.X` height-derived version, which is
+          fine because publish.yml only fires on `push: tags: '**'`.
+        -->
+        <MinVerTagPrefix>v</MinVerTagPrefix>
+
         <Authors>David Pine</Authors>
         <Copyright>© 2022-$([System.DateTime]::Now.ToString('yyyy')) David Pine</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>dotnet;dotnetcore;csharp;github;actions;devops;</PackageTags>
-        <PackageProjectUrl>https://github.com/IEvangelist/dotnet-github-actions-sdk</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/IEvangelist/dotnet-github-actions-sdk</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/IEvangelist/actions-toolkit-csharp</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/IEvangelist/actions-toolkit-csharp</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
 
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -14,7 +14,7 @@ The following table tracks the various packages' development progress. Each pack
 > `GitHub.Actions.Core` and `GitHub.Actions.Glob` will receive a final v10.x release with `[Obsolete]` annotations,
 > and the new `ActionsToolkit.*` packages will ship together as **v1.0.0** once every row below is fully ✅.
 
-[issue-5]: https://github.com/IEvangelist/dotnet-github-actions-sdk/issues/5
+[issue-5]: https://github.com/IEvangelist/actions-toolkit-csharp/issues/5
 
 | `@actions/toolkit` | Package | Exists? | Testable? | DI Friendly? | README? | Tests? | Attribution? | AOT-tested? |
 |--|--|:--:|:--:|:--:|:--:|:--:|:--:|:--:|

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-<!-- https://socialify.git.ci/IEvangelist/dotnet-github-actions-sdk?description=1&font=Rokkitt&language=1&name=1&owner=1&pattern=Plus&theme=Dark -->
+<!-- https://socialify.git.ci/IEvangelist/actions-toolkit-csharp?description=1&font=Rokkitt&language=1&name=1&owner=1&pattern=Plus&theme=Dark -->
 
-![dotnet-github-actions-sdk](https://socialify.git.ci/IEvangelist/dotnet-github-actions-sdk/image?description=1&font=Rokkitt&language=1&name=1&owner=1&pattern=Plus&theme=Dark)
+![actions-toolkit-csharp](https://socialify.git.ci/IEvangelist/actions-toolkit-csharp/image?description=1&font=Rokkitt&language=1&name=1&owner=1&pattern=Plus&theme=Dark)
 
 # GitHub Actions Workflow .NET SDK
 
-[![build-and-test](https://github.com/IEvangelist/dotnet-github-actions-sdk/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/IEvangelist/dotnet-github-actions-sdk/actions/workflows/build-and-test.yml)
-[![code analysis](https://github.com/IEvangelist/dotnet-github-actions-sdk/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/IEvangelist/dotnet-github-actions-sdk/actions/workflows/codeql-analysis.yml)
-[![publish nuget](https://github.com/IEvangelist/dotnet-github-actions-sdk/actions/workflows/publish.yml/badge.svg)](https://github.com/IEvangelist/dotnet-github-actions-sdk/actions/workflows/publish.yml)
+[![build-and-test](https://github.com/IEvangelist/actions-toolkit-csharp/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/IEvangelist/actions-toolkit-csharp/actions/workflows/build-and-test.yml)
+[![code analysis](https://github.com/IEvangelist/actions-toolkit-csharp/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/IEvangelist/actions-toolkit-csharp/actions/workflows/codeql-analysis.yml)
+[![publish nuget](https://github.com/IEvangelist/actions-toolkit-csharp/actions/workflows/publish.yml/badge.svg)](https://github.com/IEvangelist/actions-toolkit-csharp/actions/workflows/publish.yml)
 [![NuGet](https://img.shields.io/nuget/v/ActionsToolkit.Core.svg?style=flat)](https://www.nuget.org/packages/ActionsToolkit.Core) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
@@ -20,7 +20,7 @@ The .NET equivalent of the official GitHub [actions/toolkit](https://github.com/
 > once each row in [PACKAGES.md](PACKAGES.md) is fully ✅. Native AOT correctness is verified per
 > package via dedicated `tests/<pkg>.Aot.Tests` projects.
 
-[issue-5]: https://github.com/IEvangelist/dotnet-github-actions-sdk/issues/5
+[issue-5]: https://github.com/IEvangelist/actions-toolkit-csharp/issues/5
 
 ## Blog
 
@@ -122,10 +122,10 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <table>
   <tbody>
     <tr>
-      <td align="center" valign="top" width="14.28%"><a href="http://www.chethusk.com"><img src="https://avatars.githubusercontent.com/u/573979?v=4?s=100" width="100px;" alt="Chet Husk"/><br /><sub><b>Chet Husk</b></sub></a><br /><a href="https://github.com/IEvangelist/dotnet-github-actions-sdk/commits?author=baronfel" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/js6pak"><img src="https://avatars.githubusercontent.com/u/35262707?v=4?s=100" width="100px;" alt="js6pak"/><br /><sub><b>js6pak</b></sub></a><br /><a href="https://github.com/IEvangelist/dotnet-github-actions-sdk/commits?author=js6pak" title="Code">💻</a> <a href="https://github.com/IEvangelist/dotnet-github-actions-sdk/commits?author=js6pak" title="Tests">⚠️</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://david.gardiner.net.au"><img src="https://avatars.githubusercontent.com/u/384747?v=4?s=100" width="100px;" alt="David Gardiner"/><br /><sub><b>David Gardiner</b></sub></a><br /><a href="https://github.com/IEvangelist/dotnet-github-actions-sdk/commits?author=flcdrg" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://thnetii.td.org.uit.no/"><img src="https://avatars.githubusercontent.com/u/8759693?v=4?s=100" width="100px;" alt="Fredrik Høisæther Rasch"/><br /><sub><b>Fredrik Høisæther Rasch</b></sub></a><br /><a href="https://github.com/IEvangelist/dotnet-github-actions-sdk/commits?author=fredrikhr" title="Code">💻</a> <a href="#ideas-fredrikhr" title="Ideas, Planning, & Feedback">🤔</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="http://www.chethusk.com"><img src="https://avatars.githubusercontent.com/u/573979?v=4?s=100" width="100px;" alt="Chet Husk"/><br /><sub><b>Chet Husk</b></sub></a><br /><a href="https://github.com/IEvangelist/actions-toolkit-csharp/commits?author=baronfel" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/js6pak"><img src="https://avatars.githubusercontent.com/u/35262707?v=4?s=100" width="100px;" alt="js6pak"/><br /><sub><b>js6pak</b></sub></a><br /><a href="https://github.com/IEvangelist/actions-toolkit-csharp/commits?author=js6pak" title="Code">💻</a> <a href="https://github.com/IEvangelist/actions-toolkit-csharp/commits?author=js6pak" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://david.gardiner.net.au"><img src="https://avatars.githubusercontent.com/u/384747?v=4?s=100" width="100px;" alt="David Gardiner"/><br /><sub><b>David Gardiner</b></sub></a><br /><a href="https://github.com/IEvangelist/actions-toolkit-csharp/commits?author=flcdrg" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://thnetii.td.org.uit.no/"><img src="https://avatars.githubusercontent.com/u/8759693?v=4?s=100" width="100px;" alt="Fredrik Høisæther Rasch"/><br /><sub><b>Fredrik Høisæther Rasch</b></sub></a><br /><a href="https://github.com/IEvangelist/actions-toolkit-csharp/commits?author=fredrikhr" title="Code">💻</a> <a href="#ideas-fredrikhr" title="Ideas, Planning, & Feedback">🤔</a></td>
     </tr>
   </tbody>
 </table>

--- a/src/ActionsToolkit.Artifact/README.md
+++ b/src/ActionsToolkit.Artifact/README.md
@@ -164,5 +164,5 @@ Based on the original Node.js
 [`@actions/artifact`](https://github.com/actions/toolkit/tree/main/packages/artifact)
 package by GitHub. The original C# upload skeleton was contributed by
 [@js6pak](https://github.com/js6pak) in
-[#4](https://github.com/IEvangelist/dotnet-github-actions-sdk/pull/4) and
+[#4](https://github.com/IEvangelist/actions-toolkit-csharp/pull/4) and
 is preserved as the first commit on the adoption branch.

--- a/src/ActionsToolkit.HttpClient/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ActionsToolkit.HttpClient/Extensions/ServiceCollectionExtensions.cs
@@ -9,9 +9,9 @@ namespace ActionsToolkit.HttpClient.Extensions;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// The default <c>user-agent</c> HTTP header value, <c>"dotnet-github-actions-sdk"</c>.
+    /// The default <c>user-agent</c> HTTP header value, <c>"actions-toolkit-csharp"</c>.
     /// </summary>
-    public const string UserAgentHeader = "dotnet-github-actions-sdk";
+    public const string UserAgentHeader = "actions-toolkit-csharp";
 
     /// <summary>
     /// Adds the required HTTP client services to the <see cref="IServiceCollection"/>.

--- a/tests/ActionsToolkit.Octokit.Tests/GitHubClientTests.cs
+++ b/tests/ActionsToolkit.Octokit.Tests/GitHubClientTests.cs
@@ -18,7 +18,7 @@ public class GitHubClientTests
         var client = GitHubClientFactory.Create(token);
 
         var owner = "IEvangelist";
-        var repo = "dotnet-github-actions-sdk";
+        var repo = "actions-toolkit-csharp";
         var pullNumber = 1;
 
         var firstPullRequest = await client.Repos[owner][repo].Pulls[pullNumber].GetAsync();


### PR DESCRIPTION
Follow-up to the GitHub-side rename of this repository from `IEvangelist/dotnet-github-actions-sdk` to `IEvangelist/actions-toolkit-csharp` (already done via `gh repo rename` — old URLs auto-redirect via GitHub's permanent redirect). This PR propagates the new slug into the working tree and finalises MinVer's versioning anchor for the new `ActionsToolkit.*` lineage.

## Changes

### URL/badge sweep (23 occurrences across 7 files)

Byte-level UTF-8 replace of `dotnet-github-actions-sdk` → `actions-toolkit-csharp`:

| File | Replacements | Notes |
|---|---|---|
| `README.md` | 15 | socialify card + 3 workflow badges + issue link + 4 contributor commit links |
| `Directory.Build.props` | 2 | `RepositoryUrl` + `PackageProjectUrl` |
| `PACKAGES.md` | 1 | issue/PR link |
| `src/ActionsToolkit.Artifact/README.md` | 1 | PR link |
| `src/ActionsToolkit.HttpClient/Extensions/ServiceCollectionExtensions.cs` | 2 | `UserAgentHeader` const + xmldoc — **public-API change**: HTTP requests through this SDK will now send `User-Agent: actions-toolkit-csharp` instead of the old slug. Acceptable: no v1.0 published yet. |
| `tests/ActionsToolkit.Octokit.Tests/GitHubClientTests.cs` | 1 | test fixture string |
| `.all-contributorsrc` | 1 | `projectName` |

### MinVer atomic transition

`<MinVerTagPrefix>v</MinVerTagPrefix>` added to `Directory.Build.props` with a documented rationale comment block. This makes MinVer (already wired as a `GlobalPackageReference` at `v6.0.0` in `Directory.Packages.props`) ignore the legacy un-prefixed tags from the abandoned `GitHub.Actions.*` lineage:

- `8.0.x`, `9.0.0`, `10.0` (pre-rename .NET-version-aligned tags)
- `1.0.0-rc.1`..`1.0.4-rc.1` (early experimental rc series)
- `0.0.1`, `0.0.2` (very early tags)

The new `ActionsToolkit.*` lineage is keyed off `v*` tags exclusively.

### Stale tag deletion (out-of-band, already done)

The single pre-existing `v*` tag — `v1.0.4-rc.1` at SHA `7724cee` — was deleted both locally and on the remote. It was an experimental tag never associated with a published nupkg, but with `MinVerTagPrefix=v` it would have anchored versions at `1.0.4-rc.1.<height>` (semver max wins), making it impossible for a future `v1.0.0` tag to "downgrade" the version cleanly. Recovery if needed: `git tag v1.0.4-rc.1 7724cee && git push origin v1.0.4-rc.1`.

## Verification

- `dotnet build -c Release --no-restore -m:1` → 27s, **0 warn / 0 err**
- MinVer-derived nupkg name: `ActionsToolkit.Core.0.0.0-alpha.0.121.nupkg` (the canonical "no `v*` tag yet" fallback). When `v0.0.1-pre.0` lands → `ActionsToolkit.Core.0.0.1-pre.0.nupkg`. When `v1.0.0` lands → `ActionsToolkit.Core.1.0.0.nupkg`. CI must stay green on push + pr × 3 OSes.
- 0 remaining `dotnet-github-actions-sdk` strings in tracked files.

## Out of scope

- **No tag is being laid in this PR.** The `publish.yml` workflow fires on `push: tags: '**'` and would push 10 prerelease nupkgs to nuget.org using `secrets.NUGET_API_KEY` (verified present, last rotated 2025-12-11). That's a release authorisation boundary — surfaced as a follow-up decision once this PR is merged.
- **No legacy package deprecation.** `GitHub.Actions.{Core,Glob}` on nuget.org are untouched.

## Co-authored-by

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
