### PR TITLE
Security hardening: SHA-pin Actions, bump deps, Dependabot auto-merge

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
         global-json-file: global.json
 
@@ -33,7 +33,7 @@ runs:
       # but is deterministic enough to fail consistently in CI; see PR #49.
       run: dotnet build --configuration Release --no-restore -m:1
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: inputs.upload-artifacts == 'true'
       with:
         name: nuget

--- a/.github/workflows/aot-publish.yml
+++ b/.github/workflows/aot-publish.yml
@@ -44,7 +44,7 @@ jobs:
             rid: osx-arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           filter: tree:0
@@ -56,7 +56,7 @@ jobs:
           echo 'Reason: ${{ github.event.inputs.reason }}'
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
 
@@ -192,7 +192,7 @@ jobs:
 
       - name: Upload publish logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aot-publish-logs-${{ matrix.os }}-${{ matrix.rid }}
           path: aot-publish-logs/**

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           filter: tree:0
@@ -73,7 +73,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           filter: tree:0
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           filter: tree:0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
         filter: tree:0
@@ -58,7 +58,7 @@ jobs:
     
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -74,12 +74,12 @@ jobs:
     #    uses a compiled language
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
         global-json-file: global.json
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,36 @@
+name: dependabot auto-merge
+
+# Auto-merges Dependabot pull requests once required CI checks pass.
+#
+# - Triggers on PR open/sync from the `dependabot[bot]` actor.
+# - Calls `gh pr merge --auto --squash`, which queues the merge to fire as
+#   soon as every required status check is green; if a check fails the merge
+#   never happens and the PR stays open for manual review.
+# - All third-party actions are SHA-pinned (security best practice).
+
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'IEvangelist/actions-toolkit-csharp'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/examples-smoketest.yml
+++ b/.github/workflows/examples-smoketest.yml
@@ -78,13 +78,13 @@ jobs:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: '1'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           filter: tree:0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
 
@@ -323,7 +323,7 @@ jobs:
 
       - name: Upload smoketest logs
         if: failure() && steps.smoketest.outputs.log_dir != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smoketest-logs-${{ matrix.os }}
           path: ${{ steps.smoketest.outputs.log_dir }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           filter: tree:0

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,23 +4,23 @@
     <DefaultTargetFrameworks>net10.0</DefaultTargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <GlobalPackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" IncludeAssets="runtime;build;native;contentfiles;analyzers" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" />
+    <GlobalPackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" IncludeAssets="runtime;build;native;contentfiles;analyzers" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageVersion Include="Sigstore" Version="0.5.0" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" PrivateAssets="all" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="all" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
     <PackageVersion Include="GitHub.Octokit.SDK" Version="0.0.31" />
-    <PackageVersion Include="Pathological.Globbing" Version="9.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
-    <PackageVersion Include="SharpCompress" Version="0.40.0" />
-    <PackageVersion Include="ZstdSharp.Port" Version="0.8.6" />
+    <PackageVersion Include="Pathological.Globbing" Version="9.1.0" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.7" />
+    <PackageVersion Include="SharpCompress" Version="0.47.4" />
+    <PackageVersion Include="ZstdSharp.Port" Version="0.8.8" />
   </ItemGroup>
 </Project>

--- a/src/ActionsToolkit.ToolCache/DefaultToolCacheService.cs
+++ b/src/ActionsToolkit.ToolCache/DefaultToolCacheService.cs
@@ -138,7 +138,7 @@ internal sealed class DefaultToolCacheService(
         await Task.Run(() =>
         {
             using var stream = File.OpenRead(file);
-            using var reader = ReaderFactory.Open(stream);
+            using var reader = ReaderFactory.OpenReader(stream);
             var opts = new ExtractionOptions
             {
                 ExtractFullPath = true,
@@ -185,7 +185,7 @@ internal sealed class DefaultToolCacheService(
 
         await Task.Run(() =>
         {
-            using var archive = ArchiveFactory.Open(file);
+            using var archive = ArchiveFactory.OpenArchive(file);
             var opts = new ExtractionOptions
             {
                 ExtractFullPath = true,

--- a/tests/ActionsToolkit.ToolCache.Tests/ExtractionTests.cs
+++ b/tests/ActionsToolkit.ToolCache.Tests/ExtractionTests.cs
@@ -83,7 +83,7 @@ public sealed class ExtractionTests : IDisposable
         var tarPath = Path.Combine(_root, "archive.tar");
 
         using (var fs = File.Create(tarPath))
-        using (var writer = WriterFactory.Open(fs, ArchiveType.Tar, new WriterOptions(CompressionType.None)))
+        using (var writer = WriterFactory.OpenWriter(fs, ArchiveType.Tar, new WriterOptions(CompressionType.None)))
         {
             writer.Write("a.txt", srcA);
             writer.Write("b.txt", srcB);
@@ -103,7 +103,7 @@ public sealed class ExtractionTests : IDisposable
         var tarPath = Path.Combine(_root, "archive.tar.gz");
 
         using (var fs = File.Create(tarPath))
-        using (var writer = WriterFactory.Open(fs, ArchiveType.Tar, new WriterOptions(CompressionType.GZip)))
+        using (var writer = WriterFactory.OpenWriter(fs, ArchiveType.Tar, new WriterOptions(CompressionType.GZip)))
         {
             writer.Write("inner.txt", src);
         }
@@ -120,7 +120,7 @@ public sealed class ExtractionTests : IDisposable
         var src = MakeFile("flags.txt", "flagged");
         var tarPath = Path.Combine(_root, "flags.tar");
         using (var fs = File.Create(tarPath))
-        using (var writer = WriterFactory.Open(fs, ArchiveType.Tar, new WriterOptions(CompressionType.None)))
+        using (var writer = WriterFactory.OpenWriter(fs, ArchiveType.Tar, new WriterOptions(CompressionType.None)))
         {
             writer.Write("flags.txt", src);
         }


### PR DESCRIPTION
Three independent supply-chain hardening improvements bundled into one PR because they all touch the same surface area.

## 1. SHA-pin every third-party GitHub Action

All `uses:` references now resolve to a 40-char commit SHA with a trailing `# v<X.Y.Z>` comment so Dependabot continues tracking the source version. SHA pinning prevents [tag-replay supply-chain attacks](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions): an action owner (or someone who compromises their account) can repoint a major-version float tag to a malicious commit, which would silently land in CI on the next run.

| Action | Old | New | SHA |
|---|---|---|---|
| `actions/checkout` | `@v4` | v6.0.2 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/setup-dotnet` | `@v4` | v5.2.0 | `c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7` |
| `actions/upload-artifact` | `@v4` | v7.0.1 | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `github/codeql-action/{init,autobuild,analyze}` | `@v3` | v4 | `e46ed2cbd01164d986452f91f178727624ae40d7` |
| `dependabot/fetch-metadata` | (new) | v3.1.0 | `25dd0e34f4fe68f24cc83900b1fe3fe149efef98` |

Also subsumes the 3 stale Dependabot PRs #38 (codeql v3→v4), #39 (setup-dotnet v4→v5), #40 (checkout v4→v6) — they'll be auto-closed by Dependabot once this lands and the recreate cycle runs.

## 2. Bump every NuGet package to current latest stable

| Package | Old | New |
|---|---|---|
| `Microsoft.SourceLink.GitHub` | 8.0.0 | 10.0.203 |
| `MinVer` | 6.0.0 | 7.0.0 |
| `Microsoft.Extensions.DependencyInjection*` | 10.0.1 | 10.0.7 |
| `Microsoft.Extensions.Http` | 10.0.1 | 10.0.7 |
| `Microsoft.Extensions.Http.Resilience` | 10.1.0 | 10.5.0 |
| `Microsoft.NET.Test.Sdk` | 17.12.0 | 18.5.1 |
| `System.Linq.Async` | 6.0.1 | 7.0.1 |
| `System.Text.Json` | 9.0.0 | 10.0.7 |
| `SharpCompress` | 0.40.0 | 0.47.4 ⚠ |
| `ZstdSharp.Port` | 0.8.6 | 0.8.8 |
| `Pathological.Globbing` | 9.0.0 | 9.1.0 |
| `xunit.runner.visualstudio` | 3.0.1 | 3.1.5 |
| `coverlet.collector` | 6.0.4 | 10.0.0 |

⚠ **SharpCompress 0.47.0 breaking change**: removed the `Open` overloads on `ReaderFactory`/`ArchiveFactory`/`WriterFactory` in favour of `OpenReader`/`OpenArchive`/`OpenWriter`. Two call sites migrated in `src/ActionsToolkit.ToolCache/DefaultToolCacheService.cs` (tar + 7z extraction) and three in `tests/ActionsToolkit.ToolCache.Tests/ExtractionTests.cs`. No behavioural change — same return types, same parameters. Subsumes Dependabot PR #48.

## 3. Add Dependabot auto-merge workflow

`.github/workflows/dependabot-auto-merge.yml` triggers on every PR opened by `dependabot[bot]` and runs `gh pr merge --auto --squash` against it. The `--auto` flag queues a squash merge to fire as soon as every required status check passes; if any check fails the merge never happens and the PR stays open for manual review.

The workflow is repo-pinned (`github.repository == 'IEvangelist/actions-toolkit-csharp'`) so a fork accidentally enabling Actions cannot grant itself merge permission, and uses `dependabot/fetch-metadata@25dd0e3` (SHA-pinned) so the metadata extractor itself can't be supply-chain-attacked.

## Verification

- `dotnet build -c Release -m:1` → 0 warn / 0 err (~12s incremental, ~38s clean)
- `dotnet test --no-build` → **602 passed / 5 skipped / 0 failed** across the managed + AOT test matrix (10 src packages × {managed-tests, AOT-tests})
- All 5 push workflows must stay green (build-and-test ×3, aot-publish ×3, examples-smoketest ×3, codeql-analysis, test-samples, verify-test-projects)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
